### PR TITLE
Setup stanalone export to reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM node:18-alpine AS builder
 
 # ENV NODE_ENV=production
 
-WORKDIR /build
+WORKDIR /app
 COPY . .
+
 RUN npm install && npm update @orchestrator-ui/orchestrator-ui-components && npm update @orchestrator-ui/eslint-config-custom && npm update @orchestrator-ui/jest-config && npm update @orchestrator-ui/tsconfig
 RUN npm run build
 
@@ -12,11 +13,12 @@ FROM node:18-alpine AS runner
 
 # ENV NODE_ENV=production
 
-WORKDIR /app
-COPY --chown=node --from=builder /build .
+COPY --from=builder /app/.next/standalone /app
+COPY --from=builder /app/.next/static /app/.next/static
 
+WORKDIR /app
 USER node
 EXPOSE 3000
-CMD npm start
+CMD ["node", "server.js"]
 
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 module.exports = {
     reactStrictMode: false,
+    output: 'standalone',
     i18n: {
         // These are all the locales you want to support in
         // your application


### PR DESCRIPTION
Setup standalone export for Next app.
Reduces image size from 1.1GB to 177MB