### PR TITLE
626 Removes unused darktheme css file.

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,6 @@ import Head from 'next/head';
 import { QueryParamProvider } from 'use-query-params';
 
 import { EuiProvider, EuiThemeColorMode } from '@elastic/eui';
-import '@elastic/eui/dist/eui_theme_dark.min.css';
 import '@elastic/eui/dist/eui_theme_light.min.css';
 import {
     ApiClientContextProvider,


### PR DESCRIPTION
#626

Removing the darktheme css file from _app.tsx. Loading 2 css files there will not work. Effectively the light theme css was only applied. To leverage the proper usage of darktheme.css we should find a solution to either load dark of light theme css file.

Ticket for the css solution:
https://github.com/workfloworchestrator/orchestrator-ui-library/issues/1102