### PR TITLE
Fixes empty string as scope override

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -41,7 +41,7 @@ const wfoProvider: OAuthConfig<WfoUserProfile> = {
     wellKnown: OIDC_CONF_FULL_WELL_KNOWN_URL,
     authorization: {
         params: {
-            scope: NEXTAUTH_AUTHORIZATION_SCOPE_OVERRIDE ?? 'openid profile',
+            scope: NEXTAUTH_AUTHORIZATION_SCOPE_OVERRIDE || 'openid profile',
         },
     },
     idToken: true,


### PR DESCRIPTION
Using fallback in auth scope when NEXTAUTH_AUTHORIZATION_SCOPE_OVERRIDE env var is empty