### PR TITLE
1938 Overrides default base theme after EUI changed their default theme

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,6 +9,7 @@ import { QueryParamProvider } from 'use-query-params';
 
 import type { EuiSideNavItemType } from '@elastic/eui';
 import { EuiProvider, EuiThemeColorMode } from '@elastic/eui';
+import { EuiThemeAmsterdam } from '@elastic/eui';
 import {
     ColorModes,
     ConfirmationDialogContextWrapper,
@@ -97,6 +98,7 @@ function CustomApp({
                         >
                             <WfoAuth>
                                 <EuiProvider
+                                    theme={EuiThemeAmsterdam}
                                     colorMode={themeMode}
                                     modify={defaultOrchestratorTheme}
                                 >


### PR DESCRIPTION
1938

Since the introduction of EUI v100 the default theme is changed. This PR specifies the default base theme (EuiThemeAmsterdam)